### PR TITLE
drop functions from copied objects

### DIFF
--- a/dc.js
+++ b/dc.js
@@ -5,7 +5,7 @@ module.exports = function(obj) {
     }
     var to = Array.isArray(from) ? [] : {};
     seen.push(from);
-    Object.keys(from).forEach(function(key) {
+    Object.getOwnPropertyNames(from).forEach(function(key) {
       if (typeof from[key] == 'function')
         return;
       if (!from[key] || (typeof from[key] != 'object' && !Array.isArray(from[key])))

--- a/dc.js
+++ b/dc.js
@@ -1,9 +1,14 @@
 module.exports = function(obj) {
   function copy(from, seen) {
+    if (typeof from == 'function') {
+      return;
+    }
     var to = Array.isArray(from) ? [] : {};
     seen.push(from);
     Object.keys(from).forEach(function(key) {
-      if (!from[key] || (typeof from[key] != 'object' && !Array.isArray(from[key]))) 
+      if (typeof from[key] == 'function')
+        return;
+      if (!from[key] || (typeof from[key] != 'object' && !Array.isArray(from[key])))
         to[key] = from[key];
       else if (seen.indexOf(from[key]) == -1) {
         to[key] = copy(from[key], seen.slice(0));

--- a/test/dc.js
+++ b/test/dc.js
@@ -47,4 +47,23 @@ describe('destroy-circular', function() {
     assert.equal(d.b.y[1][0], '[Circular]');
     assert.equal(d.b.y[0][1], '[Circular]');
   });
+  it('should not break stringify contract (re: functions)', function () {
+    function a() {}
+    function b() {}
+    a.b = b;
+    var obj = {a: a};
+
+    assert.equal(JSON.stringify(obj), JSON.stringify(dc(obj)));
+    assert.equal(JSON.stringify(a), JSON.stringify(dc(a)));
+  });
+  it('should drop functions', function() {
+    function a(){}
+    a.foo = 'bar;';
+    a.b = a;
+    var obj = {a: a};
+
+    var d = dc(obj);
+    assert.deepEqual(d, {});
+    assert(!d.hasOwnProperty('a'));
+  });
 })


### PR DESCRIPTION
That is what `JSON.stringify()` does.
